### PR TITLE
Add Picard Dockerfile

### DIFF
--- a/deeptools/Dockerfile
+++ b/deeptools/Dockerfile
@@ -1,0 +1,7 @@
+FROM continuumio/miniconda
+MAINTAINER Alejandro Barrera <alejandro.barrera@duke.edu>
+
+RUN conda install -c bioconda deeptools
+
+# Default command to execute at startup of the container
+CMD ["conda"]

--- a/picard/Dockerfile
+++ b/picard/Dockerfile
@@ -1,0 +1,9 @@
+FROM broadinstitute/picard
+MAINTAINER Alejandro Barrera <alejandro.barrera@duke.edu>
+
+# Adaptation of the Dockerfile provided by the Broad Institue \
+#   (see https://hub.docker.com/r/broadinstitute/picard/~/dockerfile)
+
+WORKDIR /usr/picard
+ENTRYPOINT []
+CMD ["java", "-jar", "/usr/picard/picard.jar"]


### PR DESCRIPTION
I'm reusing the image provided by the Broad Institute. However, the original image has a wrapper script as Entrypoint, which does not work well with out CWL pipelines. 
I removed the entrypoint and changed the workdir so that if we need to add java parameters to the execution (e.g. -Xms512m) it works. 